### PR TITLE
Option to allow save() and delete()

### DIFF
--- a/NestedSetBehavior.php
+++ b/NestedSetBehavior.php
@@ -19,6 +19,7 @@ class NestedSetBehavior extends CActiveRecordBehavior
 	public $leftAttribute='lft';
 	public $rightAttribute='rgt';
 	public $levelAttribute='level';
+	public $allowSaveAndDelete=false;
 	private $_ignoreEvent=false;
 	private $_deleted=false;
 	private $_id;
@@ -549,6 +550,8 @@ class NestedSetBehavior extends CActiveRecordBehavior
 	 */
 	public function beforeSave($event)
 	{
+		if($this->allowSaveAndDelete)
+			return true;
 		if($this->_ignoreEvent)
 			return true;
 		else
@@ -563,6 +566,8 @@ class NestedSetBehavior extends CActiveRecordBehavior
 	 */
 	public function beforeDelete($event)
 	{
+		if($this->allowSaveAndDelete)
+			return true;
 		if($this->_ignoreEvent)
 			return true;
 		else


### PR DESCRIPTION
Useful when wanting to edit active record attributes using generated CRUD during rapid prototyping and in general when the developer understands the risks but still wants to use save() and delete() methods directly
